### PR TITLE
Added support for 2019 edition to udev rules.

### DIFF
--- a/91-pulseaudio-steelseries-arctis-5.rules
+++ b/91-pulseaudio-steelseries-arctis-5.rules
@@ -1,2 +1,3 @@
 ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1250", ENV{PULSE_PROFILE_SET}="steelseries-arctis-5-usb-audio.conf"
+ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12aa", ENV{PULSE_PROFILE_SET}="steelseries-arctis-5-usb-audio.conf"
 


### PR DESCRIPTION
A new row with the device id for the 2019 version added. Everything else seems to work directly.